### PR TITLE
Abennat adding metadata and images

### DIFF
--- a/INS0301-INS0400/INS0341DL.xml
+++ b/INS0301-INS0400/INS0341DL.xml
@@ -55,34 +55,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <placeName xml:lang="gez" corresp="#n2" type="normalized">ʿAsbo</placeName>
                <state type="existence" ref="Paks2"/>
                <country ref="wd:Q115"/>
-
-               <listBibl type="secondary">
-                  <bibl>
-                     <ptr target="bm:Turaev1906ZenaDabralibanos"/>
-                  </bibl>
-
-                  <bibl>
-                     <ptr target="bm:Solomon2016Galawdewos"/>
-                  </bibl>
-
-                  <bibl>
-                     <ptr target="bm:Conzelman1895Galawdewos"/>
-                  </bibl>
-                  <bibl>
-                     <ptr target="bm:Derat2005DabraLibanos"/>
-                  </bibl>
-                  <bibl>
-                     <ptr target="bm:Nosnitsin2010TaklaHaymanot"/>
-                  </bibl>
-                  <bibl>
-                     <ptr target="bm:Solomon2015Galawdewos"/>
-                     <citedRange unit="page">109-118</citedRange>
-                  </bibl>
-                  <bibl>
-                     <ptr target="bm:Huntingford1987Historicalgeo"/>
-                     <citedRange unit="page">7, 69, 76, 80, 83, 108, 116, 117, 120, 128, 152-4, 156, 224, 249</citedRange>
-                  </bibl>
-               </listBibl>
+               <desc facs="Sites/INS0341DL/" n="31">Images</desc>
+               
+               
                <note>
                   <date type="foundation" cert="high">It was founded by <roleName type="title">ʾabuna</roleName>
                      <persName ref="PRS9162TaklaHa"/>
@@ -107,12 +82,96 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      the position of religious centre of the monarchy. But the situation deteriorated due to the massive expansion of the
                      <persName ref="ETH1973Oromo"/> and increasing isolation of  Dabra Libānos from the rest of the Empire.
                   </ab>
+                  <ab type="description" subtype="school">All levels of the ecclesiastical education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                     <table>
+                        <row role="label">
+                           <cell role="label">School</cell>
+                           <cell role="label">Instructor</cell>
+                           <cell role="label">Students</cell>
+                        </row>                                
+                        <row>
+                           <cell><ref type="authFile" corresp="NebabBet">Nǝbāb bet</ref></cell>
+                           <cell>Mamhǝr Walda Iyyāsus, 
+                              Mamhǝr Lǝʿul, 
+                              Mamhǝr Tasfā,
+                              Mamhǝr Walda Madḫǝn
+                           </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="QeddaseBet">Qǝddāse bet</ref></cell>
+                           <cell>Mamhǝr Yamāna Bǝrhān (Retired as of 2024),
+                              Mamhǝr Ḥǝzqʾel
+                           </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                           <cell>Mamhǝr Wadāğ </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                           <cell>Mamhǝr Batra Māryam (Retired as of 2024),
+                              Mamhǝr Sǝmur
+                           </cell>
+                           <cell>more than 200</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                           <cell>Mamhǝr Kǝnfa Mikaʾel,
+                              Mamhǝr Ḥāwaz
+                           </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="MashafBet#OldT">Maṣḥāf bet: Old Testament ʾAndǝmtā</ref></cell>
+                           <cell>Maggābi bǝluy Bǝrhāna Masqal
+                           </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="MashafBet#NewT">Maṣḥāf bet: New Testament ʾAndǝmtā</ref></cell>
+                           <cell>Maggābi haddis Walda Takla Hāymānot
+                           </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                     </table>
+                  </ab>
                </note>
             </place>
             <listRelation>
                <relation name="syriaca:has-relation-to-place" active="INS0341DL" passive="LOC5597Sawa"/>
             </listRelation>
          </listPlace>
+            <listBibl type="secondary">
+               <bibl>
+                  <ptr target="bm:Turaev1906ZenaDabralibanos"/>
+               </bibl>
+               
+               <bibl>
+                  <ptr target="bm:Solomon2016Galawdewos"/>
+               </bibl>
+               
+               <bibl>
+                  <ptr target="bm:Conzelman1895Galawdewos"/>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Derat2005DabraLibanos"/>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Nosnitsin2010TaklaHaymanot"/>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Solomon2015Galawdewos"/>
+                  <citedRange unit="page">109-118</citedRange>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Huntingford1987Historicalgeo"/>
+                  <citedRange unit="page">7, 69, 76, 80, 83, 108, 116, 117, 120, 128, 152-4, 156, 224, 249</citedRange>
+               </bibl>
+            </listBibl>
+         
       </body>
    </text>
 </TEI>

--- a/INS0301-INS0400/INS0341DL.xml
+++ b/INS0301-INS0400/INS0341DL.xml
@@ -54,35 +54,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <placeName xml:lang="gez" xml:id="n2" type="alt">ዓስቦ፡</placeName>
                <placeName xml:lang="gez" corresp="#n2" type="normalized">ʿAsbo</placeName>
                <state type="existence" ref="Paks2"/>
-               <country ref="wd:Q115"/>
+               <country ref="LOC3010Ethiop">Ethiopia</country>
+               <region ref="LOC5597Sawa">Šawā</region>
                <desc facs="Sites/INS0341DL/" n="31">Images</desc>
                
                
                <note>
-                  <date type="foundation" cert="high">It was founded by <roleName type="title">ʾabuna</roleName>
-                     <persName ref="PRS9162TaklaHa"/>
-                     who is credited with evangelizing the vast regions of central and southern Ethiopia, at the beginning of the 14th century.</date>
+                  <date type="foundation" when="1284">According to the tradition it was founded by 
+                     <persName ref="PRS9162TaklaHa"/>.</date>
 
                   <ab type="history">Dabra Libānos, originally known as Dabra ʿAsbo and renamed by
-                     <roleName type="title">ʾaṣe</roleName>
+                     
                      <persName ref="PRS10626ZaraY"/> is a monastery located in
                      <placeName ref="LOC5597Sawa"/> in the gorge near the river <placeName ref="LOC6469ZegaWa"/>. This southern location has to be emphasized:
-                     the community was established between the pagan kingdom of <placeName ref="LOC2488Damot"/> and the Muslim sultanate of
+                     the community was established between the kingdom of <placeName ref="LOC2488Damot"/> and the Muslim sultanate of
                      <placeName ref="LOC5597Sawa"/> under the authority of <placeName ref="LOC3921Ifat"/>. According to the
                      hagiography of <persName ref="PRS1955Anorewos"/>, one of the first disciples of
-                     <roleName type="title">ʾabuna</roleName>
+                     
                      <persName ref="PRS9162TaklaHa"/>, the daily life was
                      under the jurisdiction of the <roleName type="title">maggābi</roleName>. It is known that the monastery enjoyed land donations at least since the half <!--which one?--> of 15th century during
-                     the reign of <roleName type="title">ʾaṣe</roleName>
+                     the reign of 
                      <persName ref="PRS10626ZaraY"/>. The monastery of Dabra Libānos
-                     suffered great destruction during the war of <persName ref="PRS1522Ahmadb"/> in <date>1532</date>.
-                     However, it revived soon under <roleName type="title">ʾaṣe</roleName>
+                     suffered great destruction during the war of <persName ref="PRS1522Ahmadb"/> in <date when="1532">1532</date>.
+                     However, it revived soon under 
                      <persName ref="PRS4428Galawdew"/>
-                     and his successor <persName ref="PRS8550sardaDe"/> during which attempts were made to elevate  the monastery to
+                     and his successor <persName ref="PRS8550sardaDe"/> during which attempts were made to elevate the monastery to
                      the position of religious centre of the monarchy. But the situation deteriorated due to the massive expansion of the
                      <persName ref="ETH1973Oromo"/> and increasing isolation of  Dabra Libānos from the rest of the Empire.
                   </ab>
-                  <ab type="description" subtype="school">All levels of the ecclesiastical education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                  <ab type="description" subtype="school">All levels of the ecclesiastical education are offered, even though some of them are not active. 
+                     According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
                      <table>
                         <row role="label">
                            <cell role="label">School</cell>
@@ -140,9 +141,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </ab>
                </note>
             </place>
-            <listRelation>
-               <relation name="syriaca:has-relation-to-place" active="INS0341DL" passive="LOC5597Sawa"/>
-            </listRelation>
          </listPlace>
             <listBibl type="secondary">
                <bibl>

--- a/INS0401-INS0500/INS0448HamaraN.xml
+++ b/INS0401-INS0500/INS0448HamaraN.xml
@@ -50,7 +50,49 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <placeName corresp="#n1" type="normalized">Ḥamara Noḫ Kidāna Mǝḥrat</placeName>
                     <country ref="wd:Q115">Ethiopia</country>
                     <settlement ref="wd:Q3624">ʾAddis ʾAbabā</settlement> 
-                    <note>                        
+                    <desc facs="Sites/INS0448HamaraN/" n="26">Images</desc>
+                    <note>      
+                        <date type="foundation" notBefore="1909" notAfter="1930">According to an additional note in a manuscript, it was established at the foot of the <placeName ref="LOC2977Entott">ʾƎnṭoṭṭo Mountain</placeName> by <persName ref="PRS9345taytuBe">Empress Ṭāytu</persName> in 1902 EC. Later, <persName ref="PRS6642MananAs">Empress Manan</persName> built a new church in 1923 EC. Rās Dastā supervised the construction work.</date>
+                        <ab type="description">Near the church, there is a holy water spring which is highly visited due to the belief of its miraculous healing power. </ab>
+                        <ab type="description" subtype="school">All levels of the ecclesiastical education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="NebabBet">Nǝbāb bet</ref></cell>
+                                    <cell>Mamhǝr Damṣa Tasammā</cell>
+                                    <cell>40</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddāse bet</ref></cell>
+                                    <cell>Mamhǝr ʾAbbā Ḥayla ʾIyyasus Mattāfariyā </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Liqa ṭabbabt Takasta Bǝrhānu </cell>
+                                    <cell>6</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Mamhǝr Yoḫannǝs Dasse   </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Mamhǝr ʾƎngdāwarq Tǝrfe </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="MashafBet#Andemta">Maṣḥāf bet: ʾAndǝmtā</ref></cell>
+                                    <cell>Mamhǝr Gǝrmā Rǝʾǝyatu </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                            </table>
+                        </ab>
                         <ab type="tabot"><ref type="authFile" corresp="CovenantMercy">Kidāna Mǝḥrat</ref>
                             </ab>                       
                         

--- a/INS0601-INS0700/INS0603AMA.xml
+++ b/INS0601-INS0700/INS0603AMA.xml
@@ -70,6 +70,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
                </location>
                <note>
                   <desc type="foundation">A famous church in Addis Ababa which was established in <date when="1920">1913 EC</date>. According to a source in the parish, Lǝğ Iyyāsu laid the corner stone of the present church and construction work commenced in <date when="1910">1903 EC</date>. Part of the funds for the completion of the building was granted by the Emperor Ḫāyla Śǝllāse I, when still Regent and Crown Prince. For various reasons, however, it was delayed for several years and was only completed in 1913 EC and the ark was placed in the new church on the 27th Tǝqǝmt. The church walls were painted by ʾAgaññahu ʾƎngǝda (+1944 EC). The gabaz, the lay head, was Fitāwrāri Hābta-Giyorgis and was succeeded by his grand son Sawʾalla Dagafu</desc>
+                  <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                     <table>
+                        <row role="label">
+                           <cell role="label">School</cell>
+                           <cell role="label">Instructor</cell>
+                           <cell role="label">Students</cell>
+                        </row>     
+                        <row>
+                           <cell><ref type="authFile" corresp="NebabBet">Nǝbab bet</ref></cell>
+                           <cell>Yeneta Gabra Hǝywat Munyye</cell>
+                           <cell>50</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="QeddaseBet">Qǝddase bet</ref></cell>
+                           <cell>Mamhǝr Muse Boggāla </cell>
+                           <cell>7</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                           <cell>Liqa Māǝmǝran Dāwit Asaffā</cell>
+                           <cell>10</cell>
+                        </row>                        
+                                                        
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                           <cell>Mamhǝr  Mangaşā Geṭu  </cell>
+                           <cell>25</cell>
+                        </row>
+                        
+                        <row>
+                           <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                           <cell>Maggābe Mǝsṭir Qaṣalā Fantǝtte (b. 1958)</cell>
+                           <cell>20</cell>
+                        </row>
+                        
+                        <row>
+                           <cell><ref type="authFile" corresp="MashafBet">Old Testament Commentary</ref></cell>
+                           <cell>Maggābe Bǝluy Lāʾǝka Māryām Hayla Māryām  </cell>
+                           <cell>n.d.</cell>
+                        </row>
+                     </table>
+                     <ref target="https://doi.org/10.25592/uhhfdm.17727">Interview with Maggābe Mǝsṭir Qaṣalā on 07.08.2023</ref></ab>
                   <ab type="tabot"><persName ref="PRS5684JesusCh#n3MadhaneAlam" type="tabot">Madḫāne ʿĀlam</persName>, <persName ref="PRS7049Michael" type="tabot">Michael</persName></ab>
                </note>
             </place>

--- a/INS0601-INS0700/INS0603AMA.xml
+++ b/INS0601-INS0700/INS0603AMA.xml
@@ -80,7 +80,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
                         </row>     
                         <row>
                            <cell><ref type="authFile" corresp="NebabBet">Nǝbab bet</ref></cell>
-                           <cell>Yeneta Gabra Hǝywat Munyye</cell>
+                           <cell>Yeneta Gabra Hǝywat Munǝyye</cell>
                            <cell>50</cell>
                         </row>
                         <row>
@@ -90,7 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
                         </row>
                         <row>
                            <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
-                           <cell>Liqa Māǝmǝran Dāwit Asaffā</cell>
+                           <cell>Liqa Māʾǝmmǝran Dāwit Asaffā</cell>
                            <cell>10</cell>
                         </row>                        
                                                         
@@ -102,7 +102,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
                         
                         <row>
                            <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
-                           <cell>Maggābe Mǝsṭir Qaṣalā Fantǝtte (b. 1958)</cell>
+                           <cell>Maggābe Mǝsṭir <persName ref="PRS14979Qasala">Qaṣalā Fantǝtte</persName> (b. 1958)</cell>
                            <cell>20</cell>
                         </row>
                         

--- a/INS0601-INS0700/INS0603AMA.xml
+++ b/INS0601-INS0700/INS0603AMA.xml
@@ -68,6 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
                <location>
                   <geo>9.057892 38.727624</geo>
                </location>
+               <desc facs="Sites/INS0603AMA/" n="23">Images</desc>
                <note>
                   <desc type="foundation">A famous church in Addis Ababa which was established in <date when="1920">1913 EC</date>. According to a source in the parish, Lǝğ Iyyāsu laid the corner stone of the present church and construction work commenced in <date when="1910">1903 EC</date>. Part of the funds for the completion of the building was granted by the Emperor Ḫāyla Śǝllāse I, when still Regent and Crown Prince. For various reasons, however, it was delayed for several years and was only completed in 1913 EC and the ark was placed in the new church on the 27th Tǝqǝmt. The church walls were painted by ʾAgaññahu ʾƎngǝda (+1944 EC). The gabaz, the lay head, was Fitāwrāri Hābta-Giyorgis and was succeeded by his grand son Sawʾalla Dagafu</desc>
                   <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 

--- a/INS0801-INS0900/INS0818Abbay.xml
+++ b/INS0801-INS0900/INS0818Abbay.xml
@@ -52,11 +52,47 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"
       <body>
          <listPlace>
             <place subtype="institution" type="church">
-               <placeName type="normalized">ʿAbbāy Mādo Qǝddus Gabrǝʾel</placeName>               
+               <placeName type="normalized" xml:id="n1">ʿAbbāy Mādo Qǝddus Gabrǝʾel</placeName>        
+               <placeName xml:id="n2" type="alt">Qǝlāğ Giyorgis</placeName>
                <country ref="wd:Q115">Ethiopia</country>
                <settlement ref="LOC1721BaherD"/>
-               <location><desc>This is a relatively new Church in the outskirt of Bāḥǝr Dār where there is a school of Dǝggwa</desc>                  
-               </location>
+               <note>
+                  <date type="foundation" when="1999">Tradition has it that this church is established in 1495 and was called Qǝlāğ Giyorgis. Then the church was burnt during the invasion of <persName ref="PRS1522Ahmadb"></persName>. The church was re-inaugurated in 1976 under a new name, ʿĀbbāy Mādo St. Gabrǝʾel.       
+                  </date>
+                  <ab type="description" subtype="school"> Currently, there are schools that train students with different fields namely, commentary, Dǝggʷā, ʾAqqʷāqʷām and Qǝddāse. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                     <table>
+                        <row role="label">
+                           <cell role="label">School</cell>
+                           <cell role="label">Instructor</cell>
+                           <cell role="label">Students</cell>
+                        </row>                               
+                        
+                        <row>
+                           <cell><ref type="authFile" corresp="QeddaseBet">Qǝddāse bet</ref></cell>
+                           <cell>Efrem ʾAndārge</cell>
+                           <cell>35</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                           <cell>Lǝbsa Warq ʿĀlamāyyahu</cell>
+                           <cell>60</cell>
+                        </row>
+                        <row>
+                           <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                           <cell>Yǝbābe Mangǝśt </cell>
+                           <cell>100</cell>
+                        </row>                               
+                                                
+                        <row>
+                           <cell><ref type="authFile" corresp="MashafBet#NewT">Maṣḥāf bet: New Testament</ref></cell>
+                           <cell>Ḥāraga Wayn Barrihun</cell>
+                           <cell>35</cell>
+                        </row>
+                     </table>
+                     
+                  </ab>
+                  <ab type="tabot"><persName ref="PRS4377Gabriel" type="tabot"></persName></ab>
+               </note>
                
             </place>
          </listPlace>

--- a/INS0901-INS1000/INS0954YohannesW.xml
+++ b/INS0901-INS1000/INS0954YohannesW.xml
@@ -49,10 +49,35 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <placeName corresp="#n1" xml:lang="gez" type="normalized">Yoḥannǝs Walda Nagʷadgʷād</placeName>
                     <country ref="wd:Q115">Ethiopia</country>
                     <settlement ref="LOC3577Gondar">Gondar</settlement>
+                    <desc facs="Sites/INS0954YohannesW/" n="4">Images</desc>
                     <note>                        
                         <ab type="tabot"><persName ref="PRS5695John#n3" type="tabot">Yoḥannǝs Walda Nagʷadgʷād</persName>
                         </ab>                       
                         <desc type="foundation">Emperor Takla Hāymānot founded the church in <date when="1769">1769</date></desc>
+                        <ab type="history">According to historical accounts, the original church was destroyed by fire during an attack by the Darbuš, and the current structure is a reconstruction. During the reign of King Takla Hāymānot, more than 170 scholars are believed to have served the Christian community. </ab>
+                        <ab type="description" subtype="school">The teaching tradition established during that time continues to this day, with the methods being preserved and practiced by disciples in two congregations.
+                            According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>     
+
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Mamhǝr ʾAmda Warq</cell>
+                                    <cell>12</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Mamhǝr ʾAbiyy Tafari </cell>
+                                    <cell>30</cell>
+                                </row>
+                                
+                            </table>
+                            
+                        </ab>
                     </note>
                 </place>
             </listPlace>

--- a/new/INS0972MahdaraSebhat.xml
+++ b/new/INS0972MahdaraSebhat.xml
@@ -50,7 +50,49 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <placeName corresp="#n1" type="normalized">Māḫǝdara Sǝbḥāt lǝdatā la-Māryām</placeName>
                     <country ref="wd:Q115">Ethiopia</country>
                     <settlement ref="wd:Q3624">ʾAddis ʾAbabā</settlement> 
-                    <note>                        
+                    <note>           
+                        <date type="foundation" when="1922">This church was inaugurated on 21 Yakkātit 1916 EC. The founder and patron of the church was <persName ref="PRS8588Sawiros">ʾƎč̣č̣age Gabra Manfas Qǝddus (later ʾAbuna Sāwiros)</persName>. The site was comparatively extensive and belonged to the ʾƎč̣č̣age’s office.
+                            The church had 40 gāšās of land for its upkeep, thirty of which belonged to the Gabaz, Lǝǧ Gabra ʾAdǝnaw, who was Mənilək’s ʾƎlfǝññ ʾAskalkāy and is sometimes known as Bālamwāl Gabre. The land was inherited by his children who have, however, no connection with the church and have even stopped the annual feast on Gǝnbot one which their father used to organize in order to commemorate the day of  Lǝdatā. 
+                            In 1963, there were 32 priests and deacons, and 38 dabtarās serving the church. Influential people attached to the church included Daǧǧāč <persName ref="PRS2435Balcasa">Bālčā ʾAbbā Nafso</persName>, Daǧǧāč ʾAsaffā Lǝʿul Saggad and <persName ref="PRS10671Zawditu">Empress Zawditu</persName>. In the 1960s <persName ref="PRS6561Makwanne">Rās Bitwaddad Makwannǝn ʾƎndālkāččaw</persName> and his wife used to support the church. The Italian forces tried to demolish the church, perhaps because they had plans to use the land for some other purpose. They forbade the use of the church and it was for some time surrounded by soldiers .</date>
+                        <ab type="description" subtype="school">All levels of the ecclesiastical education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="NebabBet">Nǝbāb bet</ref></cell>
+                                    <cell>n.d.</cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddāse bet</ref></cell>
+                                    <cell>Mamhǝr Ṭǝbaba Yiheyis </cell>
+                                    <cell>11</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Mamhǝr Dassālaññ ʾAlāmǝrrawu </cell>
+                                    <cell>15</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Liqa Māʾǝmmǝran Dāwit Asaffā</cell>
+                                    <cell>10</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Mamhǝr Zakkārias Ammbāwu </cell>
+                                    <cell>15</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="MashafBet#Andemta">Maṣḥāf bet: ʾAndǝmtā</ref></cell>
+                                    <cell>Maggābi Haddis ʾAnduʾālam</cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                            </table>
+                        </ab>
                         <ab type="tabot"><persName ref="PRS6819Mary" type="tabot">Mary</persName>
                             </ab>                       
                         

--- a/new/INS0974GMA.xml
+++ b/new/INS0974GMA.xml
@@ -1,0 +1,78 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="INS0974GMA" xml:lang="en" type="ins">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Madḫāne ʿĀlam</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="ES"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="ES" when="2025-07-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <listPlace>
+                <place type="church" subtype="institution">
+                    <placeName xml:id="n1" xml:lang="gez">መንበረ፡ መንግሥት፡ መድኃኔ፡ ዓለም፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Manbara Mangǝśt Madḫāne
+                        ʿĀlam</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">መድኃኔ፡ ዓለም፡</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Madḫāne ʿĀlam</placeName>
+                    <!--               transitteration in fidel and xml:lang assigned as gez to be checked-->
+                    <country ref="LOC3010Ethiop"/>
+                    <region notBefore="1991" type="RegionalState" ref="LOC1426Amhara"/>
+                    <region notAfter="1974" type="province" ref="LOC1713Bagemd"/>
+                    <settlement type="zone" ref="LOC6544NorthGondar"/>
+                    <settlement type="town" ref="LOC3577Gondar"/>
+                    <location>
+                        <geo cert="medium">12.6000 37.4666</geo>
+                        <!--                        used general coordinates for Gondar, i.e. not specific to this church-->
+                    </location>
+                    <desc facs="Sites/INS0974GMA/" n="8">Images</desc>
+                    <note>
+                        <ab type="description"> Manbara Mangǝśt Madḫāne ʿĀlam is one of five churches
+                            founded in the <date>17th century</date> by 
+                            <persName ref="PRS4015Fasilada">Fāsiladas</persName> outside the central
+                            nucleus comprising his stone castle in <placeName ref="LOC3577Gondar">Gondar</placeName>.</ab>
+                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, It had an active <ref type="authFile" corresp="MashafBet">a commentary school</ref>.  
+                            
+                            <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Batra Maryam Ababāw (age 37, student of ʾAndəmtā commentary), Interviewer: Senkoris Ayalew; Date: 20 May 2024</ref></ab>
+                    </note>
+                </place>
+            </listPlace>
+            <listBibl type="secondary">
+                <bibl>
+                    <ptr target="bm:BerryEtAl2005EnAeGondar"/>
+                </bibl>
+            </listBibl>
+        </body>
+    </text>
+</TEI>

--- a/new/INS0974GMA.xml
+++ b/new/INS0974GMA.xml
@@ -62,7 +62,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             founded in the <date>17th century</date> by 
                             <persName ref="PRS4015Fasilada">Fāsiladas</persName> outside the central
                             nucleus comprising his stone castle in <placeName ref="LOC3577Gondar">Gondar</placeName>.</ab>
-                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, It had an active <ref type="authFile" corresp="MashafBet">a commentary school</ref>.  
+                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, It had an active <ref type="authFile" corresp="MashafBet">a commentary school</ref>; <persName ref="PRS14973Batra"></persName> was a student there in 2024.  
                             
                             <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Batra Maryam Ababāw (age 37, student of ʾAndəmtā commentary), Interviewer: Senkoris Ayalew; Date: 20 May 2024</ref></ab>
                     </note>

--- a/new/INS0978Meskaya.xml
+++ b/new/INS0978Meskaya.xml
@@ -50,7 +50,50 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <placeName corresp="#n1" type="normalized">Mǝskāya ḫǝzunān Madḫāne ʿĀlam</placeName>
                     <country ref="wd:Q115">Ethiopia</country>
                     <settlement ref="LOC3549Gojjam">Goǧǧām</settlement> 
-                    <note>                        
+                    
+                    <note>     
+                        <date type="foundation" when="1947">The current church, erected in the 1940s, holds a significant relic with a rich history—the Tabot. During the reign of Mənilək II, this sacred ark was sent to Jerusalem, where a small church, named Madḫaneʿalam Tabot, was built in its honor. Ethiopian priests in Jerusalem conducted rituals around it. Amid the Italian invasion, Emperor Ḫayla Śəllase ordered the ark to be taken to London for safekeeping by five priests. In exile, the Emperor and his officials prayed in a chapel at Bath, housing the ark, known as Məskaya Həzunan Madḫaneʿalam, meaning "reliever of the grieved."
+                            
+                            Upon liberation, the ark returned to Addis Ababa and was initially housed in a building within the Ḫayla Śəllase Hospital compound. Later, in 1940 EC, construction began on the present church, with the ark being installed upon completion on the 24th of Miazia. The entire construction was funded by the Emperor, with Italian painter Fumana contributing to the church's paintings. The church's leadership transitioned, with ʾAbbā Hanna Jima succeeded by ʾAbbā Takla Māryām after the 1960 coup.
+                            
+                            
+                        </date>
+                        <ab type="description">Distinct from other churches, the priests, monks, and deacons associated with this church reside within its compound, forming a monastic community. Initially, the community established a workshop for crafting rugs and carpets. Additionally, in the 1950s, the compound housed two schools and a literacy class. After the fall of the imperial regime, the church came under its own management, accountable to the Orthodox Church Addis Ababa Diocese. It generates income through property rentals and operates a modern high school. Notably, 53 manuscripts have been produced at this church, some of which have contributed to the development of Amharic literature and provided insights into the power structure of the time.</ab>
+                        <ab type="description" subtype="school">Several levels of church education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="NebabBet">Nǝbāb bet</ref></cell>
+                                    <cell>Mamhǝr Lǝssāna Warq and Kidāna Māryām</cell>
+                                    <cell>n.d.</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet">Zemā bet</ref></cell>
+                                    <cell>Mamhǝr  ʾAbiyy ʾAbabāwu </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Mamhǝr  ʾEfrem ʾAnnǝmut</cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Maggābe mǝsṭir ʾIyyāsu Gabra ʾAlfā </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="MashafBet#NewT">Maṣḥāf bet: NewTestament ʾAndǝmtā</ref></cell>
+                                    <cell>Maggābe hāddis Walda Giyorgis Śǝggāwu </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                            </table>
+                        </ab>
+                        
                         <ab type="tabot"><persName ref="PRS5684JesusCh#n3MadhaneAlam" type="tabot">Madḫāne ʿĀlam</persName>
                             </ab>                       
                         

--- a/new/INS0979DabraNagwad.xml
+++ b/new/INS0979DabraNagwad.xml
@@ -51,7 +51,43 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <placeName xml:lang="gez" corresp="#n1" type="normalized">Dabra Nagʷadgʷād qǝddus Yoḥānnǝs</placeName>
                     <country ref="wd:Q115">Ethiopia</country>
                     <settlement ref="LOC3549Gojjam">Goǧǧām</settlement> 
-                    <note>                        
+                    <note>    
+                        <date type="foundation" when="1921">The church establishment was started in 1914, E.C. This church is closely related with the history of <persName ref="PRS10671Zawditu">Empress Zawditu</persName>. The Ark of this church, the Ark of St. John (<persName ref="PRS5695John#n3" type="tabot">Yoḥannǝs Walda Nagʷadgʷād</persName>) used to belong to <persName ref="PRS10378Yohanne">Emperor Yohannes IV</persName>, who later gave it to his son <persName ref="PRS2012Arayas">Ras Araya Śəllase</persName>. The Ras gave the Ark to his wife Zawditu, (later Empress) hoping that it would be of service to her. 
+                            When <persName ref="PRS2012Arayas">Ras Araya Śəllase</persName> died, Mənilək sent his notables Ligaba Walda Gabriel and Dajatch Abate to Tigray to bring his daughter back to Shoa. According to my informants 28, it was a time of heavy rain and the rivers were impassable. Zawditu stayed with the Ark at Dabra Tabor for a year. There, the Ark was placed in Mahdara Maryam church. Finally, Zawditu was brought to Addis Ababa, and she married Dajatch, later Ras Wube with whom she lived for about two years and a half. She was made to divorce him on the ground that he beat her. She was married to Dajazmatch, later Ras, Gugsa who was subsequently promoted to the governorship of Bagemdr. 
+                            When <persName ref="PRS10671Zawditu">Zawditu</persName> went again to Dabra Tabor accompanying her husband she built a chapel in her court and the Ark of St. John was placed in it. She lived at Dabra Tabor for 12 years with Ras Gugsa, and then she and her husband were called back to Addis Ababa. Lij Iyasu exiled them to fall for about two and half years. In September 1909, E.C. she was freed by Fitawrari Habta Giyorgis and other Shoan chiefs and made her Empress. She was asked to be crowned on 12 of Hidar 1909, E.C. but she refused on the ground that her favorite ark was still in Dabra Tabor. 
+                            So the coronation was postponed until the ark was brought from that place. Accordingly, Dajatch Walda Gabriel, Echagé Tadla (later ʾAbuna Sawiros) and Ligaba Habte Mikaʾel were sent to bring the ark. They arrived in Addis Ababa with the ark on Tər 29, 1909, E.C. The ark was placed in the imperial chapel of Mənilək. It was moved to St. George Church for the coronation of the Empress that took place on Yakatit 4th, 1909, E.C. the day of the celebration of the evangelist John. The Empress then gave the present site for the church and the ark was housed temporarily in an ordinary building. Finally, in 1918, E.C. the church was built. The original church, architecturally of the traditional style, was left as it stands today and a new modern church of Greek basilica style was built in 1949, E.C. due to the following story. The Duke of Harar was born on the day of the celebration of this church (the fourth of each month), and his Christian name was also Araya Yohannes. 
+                            According to my informant he used to request his father, the Emperor Ḫayla Śəllase to rebuild this church but the Emperor did not take action. The Duke died on the day of this Saint, the 4th of Gnbot 1949, E.C. On the 12th day after his death, i.e. on Ginbot 16 the Emperor went to this church and told the story to the congregation and promised to rebuild the church so as to fulfill the wishes of his late son. Thus, a new building of St. John came into existence. Moreover, the Emperor gave one large golden cross, vestments for 7 clergy and 40 gashas of land for the maintenance of the church.
+                            
+                        </date>
+                        <ab type="description" subtype="school">Several levels of church education are offered, even though some of them are not active. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddāse bet</ref></cell>
+                                    <cell>Marigetā  Ṭǝbaba Salomon</cell>
+                                    <cell>n.d.</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Mamhǝr Ṭǝʾuma Lissān Lǝngarǝh</cell>
+                                    <cell>6</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Liqa ṭabbabt Sayfa </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Marigetā Mabraqu </cell>
+                                    <cell>n.d.</cell>
+                                </row>                                
+                            </table>
+                        </ab>
                         <ab type="tabot"><persName ref="PRS5695John#n3" type="tabot">Yoḥannǝs Walda Nagʷadgʷād</persName>
                             </ab>                       
                         

--- a/new/INS0980BahrDarSA.xml
+++ b/new/INS0980BahrDarSA.xml
@@ -1,0 +1,119 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="INS0980BahrDarSA" xml:lang="en" type="ins">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Salām ʾArgiw Dabra Ṣǝyon Qǝddǝst Māryām </title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="ES"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="ES" when="2023-05-04">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="church" subtype="institution">
+                    <placeName xml:id="n1">Salām ʾArgiw Dabra Ṣǝyon Qǝddǝst Māryām</placeName>
+                    <country ref="wd:Q115">Ethiopia</country>
+                    <settlement ref="LOC1721BaherD"/>          
+                    <desc facs="Sites/INS0980BahrDarSA/" n="52">Images</desc>
+                    <note>
+                        <date type="foundation" when="1990">Established in 1983 E.C.  during the Derg regime.
+                        </date>
+                        <ab type="description" subtype="school">A church that is located inside the main campus of Bāḥr Dār University is known in its schools that train students with different fields of studies. The biggest and famous of all is the School of Qǝne where the young Qǝddus Yāred, son of the renowned Scholar of Qǝne, Yanetā Yāred Šǝfarrāw is teaching supported by his assistants called Zarāfiwočč. Born and raised by the man of Qǝne, Qǝddus established a famous urban school of Qǝne in Bāḥr Dār teaching “unto 1500 daqqa mazāmurt”.
+                            According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>     
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Lǝʿul Tārraqaññ</cell>
+                                    <cell>0</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Fǝre Sǝbḥāt ʾAnnǝlay</cell>
+                                    <cell>150</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Baqālu ʾAsras</cell>
+                                    <cell>0</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Damḍa Tasammā</cell>
+                                    <cell>0</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Nāhu Śannāy </cell>
+                                    <cell>50</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Bezā Tǝlāhun</cell>
+                                    <cell>0</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddase bet</ref></cell>
+                                    <cell>Fǝreqāl Mǝsgānāw </cell>
+                                    <cell>30</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddase bet</ref></cell>
+                                    <cell>Zalaʿālam ʾAlmāw </cell>
+                                    <cell>0</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Qǝddus Yāred </cell>
+                                    <cell>1000-1500</cell>
+                                </row>
+                            </table>
+                            <ref target="https://doi.org/10.25592/uhhfdm.17721">Qǝne teaching class by Qǝddus Yāred registered on 3 November 2022</ref>
+                        </ab>
+                        <ab type="tabot"><persName ref="PRS6819Mary" type="tabot">Mary</persName>
+                        </ab>
+                    </note>
+                    
+                </place>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/INS0980BahrDarSA.xml
+++ b/new/INS0980BahrDarSA.xml
@@ -102,7 +102,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </row>
                                 <row>
                                     <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
-                                    <cell>Qǝddus Yāred </cell>
+                                    <cell><persName ref="PRS14980Qeddus">Qǝddus Yāred</persName> </cell>
                                     <cell>1000-1500</cell>
                                 </row>
                             </table>

--- a/new/INS0993BahrDarTH.xml
+++ b/new/INS0993BahrDarTH.xml
@@ -68,11 +68,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </row>
                                 <row>
                                     <cell><ref type="authFile" corresp="MashafBet#OldT">Maṣḥāf bet: Old Testament</ref></cell>
-                                    <cell>Məsṭirasəllāse ʾAmānuʾel</cell>
+                                    <cell>Məsṭirasəllāse Mānāyya (until 2022)</cell>
                                     <cell>n.d.</cell>
                                 </row>                                
                             </table>
-                            <ref target="https://doi.org/10.25592/uhhfdm.17723">Interview with Maggăbe Bəluy (aged 40) Məsṭirasəllāse ʾAmānuʾel conducted on 12.07.2023       </ref>
+                            <ref target="https://doi.org/10.25592/uhhfdm.17723">Interview with Maggăbe Bəluy (aged 40) Məsṭirasəllāse Mānāyya (formerly teacher at Bāhǝr Dār Takla Hāymānot, now teacher at Bəsrāta Gabrəʾel ʾAddis ʾAbabā) conducted on 12.07.2023</ref>
                         </ab>
                         <ab type="tabot"><persName ref="PRS9162TaklaHa" type="tabot"></persName></ab>
                     </note>

--- a/new/INS0993BahrDarTH.xml
+++ b/new/INS0993BahrDarTH.xml
@@ -72,7 +72,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                     <cell>n.d.</cell>
                                 </row>                                
                             </table>
-                            <ref target="https://doi.org/10.25592/uhhfdm.17723">Interview with Maggăbe Bəluy (aged 40) Məsṭirasəllāse Mānāyya (formerly teacher at Bāhǝr Dār Takla Hāymānot, now teacher at Bəsrāta Gabrəʾel ʾAddis ʾAbabā) conducted on 12.07.2023</ref>
+                            <ref target="https://doi.org/10.25592/uhhfdm.17723">Interview with Maggăbe Bəluy (aged 40) Məsṭiraśəllāse Mānāyya (formerly teacher at Bāhǝr Dār Takla Hāymānot, now teacher at Bəśrāta Gabrəʾel ʾAddis ʾAbabā) conducted on 12.07.2023</ref>
                         </ab>
                         <ab type="tabot"><persName ref="PRS9162TaklaHa" type="tabot"></persName></ab>
                     </note>

--- a/new/INS0993BahrDarTH.xml
+++ b/new/INS0993BahrDarTH.xml
@@ -44,13 +44,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPlace>
-                <place type="church" subtype="institution">
-                    <placeName>Bāhǝr Dār Takla Hāymānot</placeName>
+                <place type="church monastery gadam" subtype="institution">
+                    <placeName xml:id="n1">Bāhǝr Dār Takla Hāymānot</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ፈለገ፡ ግዮን፡ አቡነ፡ ተክለ፡ ሃይማኖት፡ </placeName>
+                    <placeName corresp="#n2" type="normalized">Falaga Gǝyon ʾAbuna Takla Hāymānot </placeName>
                     <country ref="wd:Q115">Ethiopia</country>
-                    <settlement ref="LOC1721BaherD"/>
+                    <settlement ref="LOC1721BaherD"/>                    
                     <note>
+                        <date type="foundation" when="1999">This monastery located on the adjacent of Tana See in the Eastern side of Bāḥr Dār, on the side of the course of ʾAbbāy River, is founded in 1999 where eleven monks are residing. 
+                        </date>
+                        <ab type="description" subtype="school">The monastery is famous for its school of commentary. The four department of the school of commentary are established. The instructor, Liqa Liqāwǝnt Sǝmʿākona Malʾak is teaching 50 students. Māʿbal Faṭṭana, a renowned scholar in Qǝne and commentary, assists him. 
+                            Located on the Southern side of Bāḥər Dar, on the side of the course of ʾAbbāy River, this monastery is known for its school of commentary. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>    
+                                <row>
+                                    <cell><ref type="authFile" corresp="MashafBet#Andemta">Maṣḥāf bet: ʾAndǝmtā</ref></cell>
+                                    <cell>Liqa Liqāwǝnt Sǝmʿākona Malʾak and Māʿbal Faṭṭana</cell>
+                                    <cell>50</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="MashafBet#OldT">Maṣḥāf bet: Old Testament</ref></cell>
+                                    <cell>Məsṭirasəllāse ʾAmānuʾel</cell>
+                                    <cell>n.d.</cell>
+                                </row>                                
+                            </table>
+                            <ref target="https://doi.org/10.25592/uhhfdm.17723">Interview with Maggăbe Bəluy (aged 40) Məsṭirasəllāse ʾAmānuʾel conducted on 12.07.2023       </ref>
+                        </ab>
                         <ab type="tabot"><persName ref="PRS9162TaklaHa" type="tabot"></persName></ab>
                     </note>
+                    
                 </place>
             </listPlace><!---->
         </body>

--- a/new/INS0993BahrDarTH.xml
+++ b/new/INS0993BahrDarTH.xml
@@ -63,12 +63,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </row>    
                                 <row>
                                     <cell><ref type="authFile" corresp="MashafBet#Andemta">Maṣḥāf bet: ʾAndǝmtā</ref></cell>
-                                    <cell>Liqa Liqāwǝnt Sǝmʿākona Malʾak and Māʿbal Faṭṭana</cell>
+                                    <cell>Liqa Liqāwǝnt Sǝmʿākona Malʾak assisted by Māʿbal Faṭṭana</cell>
                                     <cell>50</cell>
                                 </row>
                                 <row>
                                     <cell><ref type="authFile" corresp="MashafBet#OldT">Maṣḥāf bet: Old Testament</ref></cell>
-                                    <cell>Məsṭirasəllāse Mānāyya (until 2022)</cell>
+                                    <cell><persName ref="PRS14978Mestir">Məśṭiraśəllāse Mānāyya</persName> (until 2022)</cell>
                                     <cell>n.d.</cell>
                                 </row>                                
                             </table>

--- a/new/INS0994GondarDBS.xml
+++ b/new/INS0994GondarDBS.xml
@@ -44,11 +44,84 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPlace>
-                <place  type="church" subtype="institution">
-                    <placeName>Dabra Bǝrhān Śǝllāse</placeName>
-                    <country ref="wd:Q115">Ethiopia</country>
-                    <settlement ref="LOC3577Gondar">Gondar</settlement>
-                    <note><desc type="foundation">Located on a hill in the north-west side of the city, this church is one of the famous churches in Gondar town. It was founded in <date when="1694">January 1694</date> during the reign of ʾaṣe Iyyāsu I. </desc></note>
+                <place  type="church" subtype="institution" sameAs="wd:Q3580176">
+                    <placeName xml:id="n1" xml:lang="gez">ደብረ፡ ብርሃን፡ ሥላሴ፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dabra Bǝrhān
+                        Śǝllāse</placeName>
+                    <placeName corresp="#n1" xml:lang="en">Mount of Light of the Trinity</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ሥሉስ፡ ቅዱስ፡</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Śǝllus Qǝddus</placeName>
+                    <country ref="LOC3010Ethiop"/>
+                    <region notBefore="1991" type="RegionalState" ref="LOC1426Amhara"/>
+                    <region notAfter="1974" type="province" ref="LOC1713Bagemd"/>
+                    <settlement type="zone" ref="LOC6544NorthGondar"/>
+                    <settlement type="town" ref="LOC3577Gondar"/>
+                    <location>
+                        <geo>12.616667 37.483333</geo>
+                    </location>
+                    <desc facs="Sites/INS0994GondarDBS/" n="4">Images</desc>
+                    <note>
+                        <date type="foundation">1694</date>
+                        <ab type="history">Dabra Bǝrhān Śǝllāse was an influential church situated on an
+                            elevated land north-west of <placeName ref="LOC3577Gondar">Gondar</placeName>
+                            and consecrated in <date>1694</date> during the reign of <roleName type="title">ʾaṣe</roleName>
+                            <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>. The original establishment
+                            included 170 clergy and generous land grants. In this church the <roleName type="function">emperor</roleName> and his court celebrated the Feast of the
+                            Trinity. The church was destroyed by lightning in <date>1707</date> but
+                            immediately rebuilt. Probably between <date>1800</date> and <date>1830</date>,
+                            it was replaced by the current rectangular building which survived the attack
+                            of Gondar by the dervishes in <date>1888</date>.</ab>
+                        <ab type="description">Dabra Bǝrhān Śǝllāse is described in both the <ref type="work" corresp="LIT3950ChronIyasu">Chronicle</ref> and in the Vita of
+                            <persName ref="PRS5616IyasuI">ʾIyāsu I</persName>. The <roleName type="function">emperor</roleName> himself prescribed that the round walls
+                            had to be four cubits thick and exactly one hundred cubits from north to south
+                            and from east to west. The central part of the church was encircled by twelve
+                            entrances with twelve pillars supporting arcades. The roof was surmounted by a
+                            gold roof decoration (gullǝlat) and a large gold cross holding spheres the size
+                            of ostrich eggs. The belfry had two large bells. The rectangular church built
+                            in the <date>19th century</date> has a rectangular hall with a half-circular
+                            apse at the east end, three entrances (north, south, west) and a thatched roof.
+                            The inside of the church is completely covered by paintings.</ab>
+                        
+                        <ab type="description" subtype="school">
+                            According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>     
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Yoḥannǝs ʾAlamu</cell>
+                                    <cell>100</cell>
+                                </row>            
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Māhtot Tasfā (b. 1966)</cell>
+                                    <cell>80</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeddaseBet">Qǝddase bet</ref></cell>
+                                    <cell>Yoḥannǝs ʾAbarrā </cell>
+                                    <cell>50</cell>
+                                </row>                                
+                                <row>
+                                    <cell><ref type="authFile" corresp="QeneBet">Qǝne bet</ref></cell>
+                                    <cell>Tǝḥtǝnna Fantāyye  </cell>
+                                    <cell>200</cell>
+                                </row>
+                            </table>
+                            <ref target="https://doi.org/10.25592/uhhfdm.14599">See the interview with Māhtot Tasfā  (b. 1966) conducted on 16 May 2024</ref>
+                        </ab>
+                    </note>
+                    <listBibl type="secondary">
+                        <bibl>
+                            <ptr target="bm:BerryEtAl2005EnAeGondar"/>
+                        </bibl>
+                        <bibl>
+                            <ptr target="bm:PankhurstBalicka2005EnAeDabraBS"/>
+                        </bibl>
+                    </listBibl>
                 </place>
             </listPlace><!---->
         </body>

--- a/new/INS0994GondarDBS.xml
+++ b/new/INS0994GondarDBS.xml
@@ -97,7 +97,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </row>            
                                 <row>
                                     <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
-                                    <cell>Māhtot Tasfā (b. 1966)</cell>
+                                    <cell><persName ref="PRS14972Mahtot">Māhtot Tasfā</persName> (b. 1966)</cell>
                                     <cell>80</cell>
                                 </row>                                
                                 <row>

--- a/new/INS0995GondarBLM.xml
+++ b/new/INS0995GondarBLM.xml
@@ -44,7 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPlace>
-                <place  type="church" subtype="institution">
+                <place  type="church" subtype="institution" sameAs="wd:Q135336990">
                     <placeName xml:id="n1" xml:lang="gez">በአታ፡ ለማርያም፡</placeName>
                     <placeName corresp="#n1" xml:lang="gez" type="normalized">Baʾatā
                         Lamāryām</placeName>
@@ -62,7 +62,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <geo cert="medium">12.6020 37.46100</geo>
                         
                     </location>
-                    <note><desc type="foundation">Founded in <date when="1771">1771</date> during the reign of Emperor Takla Hāymānot</desc></note>
+                    <desc facs="Sites/INS0995GondarBLM/" n="24">Images</desc>
+                    <note><desc type="foundation">Founded in <date when="1771">1771</date> during the reign of Emperor Takla Hāymānot</desc>
+                        <ab type="description" subtype="school">As of 2024, the church has more than 50 teachers from Komen and ʾAābər Zemā serving the church. This group of scholars is credited with dismantling the teachings of the ʾAqqʷāqʷām and leading to the establishment of a meeting house for the followers of the ʾAqqʷāqʷām tradition. According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, the following levels  of traditional education were avaialable: 
+                            <table>
+                                <row role="label">
+                                    <cell role="label">School</cell>
+                                    <cell role="label">Instructor</cell>
+                                    <cell role="label">Students</cell>
+                                </row>        
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Deggwa">Zemā bet: Dǝggʷā</ref></cell>
+                                    <cell>Mamhǝr Kide </cell>
+                                    <cell>n.d.</cell>
+                                </row>
+                                <row>
+                                    <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
+                                    <cell>Mamhǝr (Maggābe aʿlāf) Kǝbur Tǝlāhun (b. 1967); Candidates: ʾAfawarq Daməlle(b. 1984), Laʿālam Dammaqa (b. 1985), Lakullu Tilāhun (b. 1989)</cell>
+                                    <cell>175</cell>
+                                </row>
+                            </table>
+                            <ref target="https://doi.org/10.25592/uhhfdm.14599">See the interview with Mamhǝr Kǝbur Tǝlāhun (ʾAqqʷāqʷām teacher) of 16 May 2024</ref>; 
+                            <ref target="https://doi.org/10.25592/uhhfdm.14599">See the interview with Mamhǝr Laʿālam Dammaqa (ʾAqqʷāqʷām candidate) of 24 May 2024</ref>;  <ref target="https://doi.org/10.25592/uhhfdm.14599">See the interview with Mamhǝr Lakullu Tilāhun (ʾAqqʷāqʷām candidate) of 24 May 2024</ref>, <ref target="https://doi.org/10.25592/uhhfdm.14599">See the interview with Mamhǝr  ʾAfawarq Daməlle (ʾAqqʷāqʷām candidate) of 20 May 2024</ref>
+                        </ab></note>
                 </place>
             </listPlace>
             <listRelation>

--- a/new/INS0995GondarBLM.xml
+++ b/new/INS0995GondarBLM.xml
@@ -78,7 +78,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </row>
                                 <row>
                                     <cell><ref type="authFile" corresp="ZemaBet#Aqwaqwam">Zemā bet: ʾAqqʷāqʷām</ref></cell>
-                                    <cell>Mamhǝr (Maggābe aʿlāf) Kǝbur Tǝlāhun (b. 1967); Candidates: ʾAfawarq Daməlle(b. 1984), Laʿālam Dammaqa (b. 1985), Lakullu Tilāhun (b. 1989)</cell>
+                                    <cell>Mamhǝr (Maggābe aʿlāf) <persName ref="PRS14970Kebur">Kǝbur Tǝlāhun</persName> (b. 1967); Candidates: <persName ref="PRS14974Afawarq">ʾAfawarq Daməlle</persName> (b. 1984), <persName ref="PRS14976Laalam">Laʿālam Dammaqa</persName> (b. 1985), <persName ref="PRS14975Lakullu">Lakullu Tilāhun</persName> (b. 1989)</cell>
                                     <cell>175</cell>
                                 </row>
                             </table>

--- a/new/INS0996GGabriel.xml
+++ b/new/INS0996GGabriel.xml
@@ -1,0 +1,94 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="INS0996GGabriel" xml:lang="en" type="ins">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAbun Bet Gabrǝʾel</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="ES"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="ES" when="2025-07-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:base="https://betamasaheft.eu/">
+        <body>
+            <listPlace>
+                <place type="church" subtype="institution">
+                    <placeName xml:id="n1" xml:lang="gez">ገብርኤል፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Gabrǝʾel</placeName>
+                    <placeName xml:id="n2">ʾAbun Bet Gabrǝʾel</placeName>
+                    <country ref="LOC3010Ethiop"/>
+                    <region notBefore="1991" type="RegionalState" ref="LOC1426Amhara"/>
+                    <region notAfter="1974" type="province" ref="LOC1713Bagemd"/>
+                    <settlement type="zone" ref="LOC6544NorthGondar"/>
+                    <settlement type="town" ref="LOC3577Gondar"/>
+                    <location>
+                        <geo cert="medium">12.6154 37.4681</geo>
+                    </location>
+                    <desc facs="Sites/INS0996GGabriel/" n="27">Images</desc>
+                    <note>
+                        <ab type="description">Gabrǝʾel is a church north of <placeName ref="LOC3577Gondar">Gondar</placeName>, at the foot of <placeName ref="LOC3288Gannat">Gannat Tarrā</placeName> hill. <roleName type="title">ʾAbuna</roleName>
+                            <persName ref="PRS10450YosabI">Yosab</persName> moved his residence
+                            (cfr. <placeName ref="LOC1058AbunBe">ʾAbun Bet</placeName>) near
+                            Gabrǝʾel Church during the reign of <roleName type="title">ʾaṣe</roleName>
+                            <persName ref="PRS9153TaklaHa">Takla Hāymānot</persName>, while before
+                            it used to be near the church of <placeName ref="LOC6540Entone">ʾAbbā
+                                ʾƎnṭonǝs</placeName> in the north-western part of 
+                            <placeName ref="LOC3577Gondar">Gondar</placeName>. During the Italian
+                            occupation, <placeName ref="LOC1058AbunBe">ʾAbun Bet</placeName> was
+                            moved near <placeName ref="LOC6541DabraSahaySell">Dabra Ḍahāy
+                                Śǝllāse</placeName> church in the central part of the city, while
+                            the site near Gabrǝʾel church was restored after the Italians were
+                            expelled in <date>1941</date>.</ab>
+                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, It had an active <ref type="authFile" corresp="QeneBet">Qǝne bet</ref>.  
+                            
+                            <ref target="https://doi.org/10.25592/uhhfdm.14599">Class activities recorded on 6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Tewodros Abbaba (age 29, Qəne candidate/ Zarāfi), Interviewer: Senkoris Ayalew; Date:  6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Naq'a Təbab Ešate (age 71, Maggābe Məstirat), Interviewer: Senkoris Ayalew; Date: 19 May 2024</ref></ab>
+                    </note>
+                </place>
+                <listRelation>
+                    <relation name="gn:nearBy" active="INS0996Gabriel" passive="LOC3288Gannat"/>
+                    <relation name="dc:relation" active="INS0996Gabriel" passive="LOC1058AbunBe"/>
+                </listRelation>                
+            </listPlace>
+            <listBibl type="secondary">
+                <bibl>
+                    <ptr target="bm:BerryEtAl2005EnAeGondar"/>
+                </bibl>
+                <bibl>
+                    <ptr target="bm:Wubneh2003EnAeAbunBet"/>
+                </bibl>
+            </listBibl>
+        </body>
+    </text>
+</TEI>

--- a/new/INS0996GGabriel.xml
+++ b/new/INS0996GGabriel.xml
@@ -71,9 +71,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 Śǝllāse</placeName> church in the central part of the city, while
                             the site near Gabrǝʾel church was restored after the Italians were
                             expelled in <date>1941</date>.</ab>
-                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, It had an active <ref type="authFile" corresp="QeneBet">Qǝne bet</ref>.  
+                        <ab type="description" subtype="school">According to the information obtained in <date notBefore="2020" notAfter="2024">2020-2024</date> by the <ref target="https://www.aai.uni-hamburg.de/en/ethiostudies/research/abennat.html">ʾAbǝnnat project</ref>, it had an active <ref type="authFile" corresp="QeneBet">Qǝne bet</ref>, where <persName ref="PRS14971Naqa"></persName> was teaching.  His student <persName ref="PRS14977Tewodros"></persName> was interviewed in 2024.
                             
-                            <ref target="https://doi.org/10.25592/uhhfdm.14599">Class activities recorded on 6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Tewodros Abbaba (age 29, Qəne candidate/ Zarāfi), Interviewer: Senkoris Ayalew; Date:  6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Naq'a Təbab Ešate (age 71, Maggābe Məstirat), Interviewer: Senkoris Ayalew; Date: 19 May 2024</ref></ab>
+                            See <ref target="https://doi.org/10.25592/uhhfdm.14599">Class activities recorded on 6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Tewodros Abbaba (age 29, Qəne candidate/ Zarāfi), Interviewer: Senkoris Ayalew; Date:  6 January 2024</ref>; <ref target="https://doi.org/10.25592/uhhfdm.14599">Interview with Mamhər Naq'a Təbab Ešate (age 71, Maggābe Məstirat), Interviewer: Senkoris Ayalew; Date: 19 May 2024</ref></ab>
                     </note>
                 </place>
                 <listRelation>


### PR DESCRIPTION
I have added metadata and links to interviews and images which I could identify.
https://github.com/BetaMasaheft/Documentation/issues/3065
The institutions metadata word document contains
- ደብረ ሰላም ቅዱስ እስጢፋኖስ (Dabra Salām Qəddus ʾƎsṭifānos)
We had no manuscripts from there and I could not identify any folder with files belonging there so not created as cannot identify. Is the one in Bole? But where are the materials?

The disk contains folders called 
- Gondar Gabriel
- Gondar Sellase different from Dabra Berhan Sellase - folder empty
- Menbere Mengist Medhanealem
We had no manuscripts from there and I could not identify any metadata in the word document - created Abun Bet Gabriel and Gondar Madhanealem to accommodate interviews
