### PR TITLE
Create INS1027Garratts.xml

### DIFF
--- a/new/INS1027Garratts.xml
+++ b/new/INS1027Garratts.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="INS1027Garratts" xml:lang="en" type="ins">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Garratts Hall Library</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-09-29">Created record</change>
+            <!-- Add change note after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="privateHouse" subtype="institution">
+                    <placeName>Garratts Hall Library</placeName>
+                    <settlement ref="Q2280322">Banstead</settlement>
+                    <district ref="Q23276">Surrey, England</district>
+                    <country ref="wd:Q145">United Kingdom</country>
+                </place>
+            </listPlace>
+            <listBibl type="secondary">
+                <bibl><ptr target="bm:Banstead2022Garratts"/></bibl>
+            </listBibl>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
According to my suggestion in https://github.com/BetaMasaheft/Documentation/issues/3158.

When creating the record, there was type="wd:" prefilled. There is no wikidata entry for Garratts Hall Library at the moment. I will try to login wikidata and create a record for Garratts Hall Library

I would like to add the information, that this was the private residence of the Lambert family, but I saw no space in the record for it. However, with the bibl note, I think, the information should be retrievable.